### PR TITLE
Fix empty array/objects parsing

### DIFF
--- a/VbsJson.vbs
+++ b/VbsJson.vbs
@@ -187,6 +187,7 @@ Class VbsJson
         c = Mid(str, idx, 1)
         
         If c = "}" Then
+            idx = idx + 1
             Exit Function
         ElseIf c <> """" Then
             Err.Raise 8732,,"Expecting property name"
@@ -237,6 +238,7 @@ Class VbsJson
         c = Mid(str, idx, 1)
 
         If c = "]" Then
+            idx = idx + 1
             ParseArray = values.Items
             Exit Function
         End If


### PR DESCRIPTION
When parsing sometyhing like `"tags": []` then `ParseArray` would bail-out too quickly, w/o incrementing current position past closing ]

The same off-by-one error was plaguing `ParseObject` but was not raising a parse error but just silently leaving everyhting past the empty object unparsed i.e. on `"first_probe": {}, "second_probe": 123` then `second_probe` would not get parsed at all.